### PR TITLE
Add option to not provide return type to `map`/`collect`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ authors = ["Mason Protter <mason.protter@icloud.com>"]
 version = "0.2.0"
 
 [deps]
+BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
 StableTasks = "91464d47-22a1-43fe-8b7f-2d57ee82463f"
 
 [compat]
+BangBang = "0.4"
 ChunkSplitters = "2.1"
 StableTasks = "0.1"
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -6,192 +6,230 @@ This is meant to be a simple, unambitious package that provides basic, user-frie
 multithreaded calculations via higher-order functions, with a focus on [data parallelism](https://en.wikipedia.org/wiki/Data_parallelism).
 
 It re-exports the very useful function `chunks` from [ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl), and
-provides the following functions: 
+provides the following functions:
 
 <details><summary> tmapreduce </summary>
 <p>
 
-    tmapreduce(f, op, A::AbstractArray;
-               [init],
-               nchunks::Int = 2 * nthreads(),
-               split::Symbol = :batch,
-               schedule::Symbol =:dynamic,
-               outputtype::Type = Any)
+```
+tmapreduce(f, op, A::AbstractArray;
+           [init],
+           nchunks::Int = 2 * nthreads(),
+           split::Symbol = :batch,
+           schedule::Symbol =:dynamic,
+           outputtype::Type = Any)
+```
 
-A multithreaded function like `Base.mapreduce`. Perform a reduction over `A`, applying a single-argument
-function `f` to each element, and then combining them with the two-argument function `op`. `op` **must** be an
-[associative](https://en.wikipedia.org/wiki/Associative_property) function, in the sense that
-`op(a, op(b, c)) ≈ op(op(a, b), c)`. If `op` is not (approximately) associative, you will get undefined
-results. 
+A multithreaded function like `Base.mapreduce`. Perform a reduction over `A`, applying a single-argument function `f` to each element, and then combining them with the two-argument function `op`. `op` **must** be an [associative](https://en.wikipedia.org/wiki/Associative_property) function, in the sense that `op(a, op(b, c)) ≈ op(op(a, b), c)`. If `op` is not (approximately) associative, you will get undefined results. 
 
 For a very well known example of `mapreduce`, `sum(f, A)` is equivalent to `mapreduce(f, +, A)`. Doing
 
-     tmapreduce(√, +, [1, 2, 3, 4, 5])
+```
+ tmapreduce(√, +, [1, 2, 3, 4, 5])
+```
 
 is the parallelized version of
 
-     (√1 + √2) + (√3 + √4) + √5
+```
+ (√1 + √2) + (√3 + √4) + √5
+```
 
 This data is divided into chunks to be worked on in parallel using [ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl).
 
 ## Keyword arguments:
 
-- `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
-- `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-- `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
+  * `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
+  * `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+  * `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
+  * `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
+  * `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
+
 needed if you are using a `:static` schedule, since the `:dynamic` schedule is uses [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl), but if you experience problems with type stability, you may be able to recover it with the `outputtype` keyword argument.
+
 
 </details>
 </p>
 
-____________________________________
+____________________________
 
 <details><summary> treducemap </summary>
 <p>
 
-    treducemap(op, f, A::AbstractArray;
-               [init],
-               nchunks::Int = 2 * nthreads(),
-               split::Symbol = :batch,
-               schedule::Symbol =:dynamic,
-               outputtype::Type = Any)
+```
+treducemap(op, f, A::AbstractArray;
+           [init],
+           nchunks::Int = 2 * nthreads(),
+           split::Symbol = :batch,
+           schedule::Symbol =:dynamic,
+           outputtype::Type = Any)
+```
 
-Like `tmapreduce` except the order of the `f` and `op` arguments are switched. Perform a reduction over `A`,
-applying a single-argument function `f` to each element, and then combining them with the two-argument
-function `op`. `op` **must** be an [associative](https://en.wikipedia.org/wiki/Associative_property) function,
-in the sense that `op(a, op(b, c)) ≈ op(op(a, b), c)`. If `op` is not (approximately) associative, you will
-get undefined results.
+Like `tmapreduce` except the order of the `f` and `op` arguments are switched. This is sometimes convenient with `do`-block notation. Perform a reduction over `A`, applying a single-argument function `f` to each element, and then combining them with the two-argument function `op`. `op` **must** be an [associative](https://en.wikipedia.org/wiki/Associative_property) function, in the sense that `op(a, op(b, c)) ≈ op(op(a, b), c)`. If `op` is not (approximately) associative, you will get undefined results.
 
 For a very well known example of `mapreduce`, `sum(f, A)` is equivalent to `mapreduce(f, +, A)`. Doing
 
-     treducemap(+, √, [1, 2, 3, 4, 5])
+```
+ treducemap(+, √, [1, 2, 3, 4, 5])
+```
 
 is the parallelized version of
 
-     (√1 + √2) + (√3 + √4) + √5
-
+```
+ (√1 + √2) + (√3 + √4) + √5
+```
 
 This data is divided into chunks to be worked on in parallel using [ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl).
 
 ## Keyword arguments:
 
-- `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
-- `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling should be preferred since it is more flexible and better at load balancing, and more likely to be type stable. However, `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-- `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
+  * `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
+  * `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+  * `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
+  * `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling should be preferred since it is more flexible and better at load balancing, and more likely to be type stable. However, `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
+  * `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
+
 needed if you are using a `:static` schedule, since the `:dynamic` schedule is uses [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl), but if you experience problems with type stability, you may be able to recover it with the `outputtype` keyword argument.
+
 
 </details>
 </p>
 
-____________________________________
+____________________________
 
-<details><summary>treduce</summary>
+<details><summary> treduce </summary>
 <p>
 
+```
+treduce(op, A::AbstractArray; [init],
+        nchunks::Int = 2 * nthreads(),
+        split::Symbol = :batch,
+        schedule::Symbol =:dynamic,
+        outputtype::Type = Any)
+```
 
-    treduce(op, A::AbstractArray; [init],
-            nchunks::Int = 2 * nthreads(),
-            split::Symbol = :batch,
-            schedule::Symbol =:dynamic,
-            outputtype::Type = Any)
-
-Like `tmapreduce` except the order of the `f` and `op` arguments are switched. Perform a reduction over `A`,
-applying a single-argument function `f` to each element, and then combining them with the two-argument
-function `op`. `op` **must** be an [associative](https://en.wikipedia.org/wiki/Associative_property) function,
-in the sense that `op(a, op(b, c)) ≈ op(op(a, b), c)`. If `op` is not (approximately) associative, you will
-get undefined results.
+Like `tmapreduce` except the order of the `f` and `op` arguments are switched. Perform a reduction over `A`, applying a single-argument function `f` to each element, and then combining them with the two-argument function `op`. `op` **must** be an [associative](https://en.wikipedia.org/wiki/Associative_property) function, in the sense that `op(a, op(b, c)) ≈ op(op(a, b), c)`. If `op` is not (approximately) associative, you will get undefined results.
 
 For a very well known example of `reduce`, `sum(A)` is equivalent to `reduce(+, A)`. Doing
 
-     treduce(+, [1, 2, 3, 4, 5])
+```
+ treduce(+, [1, 2, 3, 4, 5])
+```
 
 is the parallelized version of
 
-     (1 + 2) + (3 + 4) + 5
-
+```
+ (1 + 2) + (3 + 4) + 5
+```
 
 This data is divided into chunks to be worked on in parallel using [ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl).
 
 ## Keyword arguments:
 
-- `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
-- `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-- `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
+  * `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
+  * `nchunks::Int` (default 2 * nthreads()) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+  * `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
+  * `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
+  * `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
+
 needed if you are using a `:static` schedule, since the `:dynamic` schedule is uses [StableTasks.jl](https://github.com/MasonProtter/StableTasks.jl), but if you experience problems with type stability, you may be able to recover it with the `outputtype` keyword argument.
+
 
 </details>
 </p>
 
-____________________________________
+____________________________
 
-<details><summary>tforeach</summary>
+<details><summary> tmap </summary>
 <p>
 
-    tforeach(f, A::AbstractArray;
-             nchunks::Int = 2 * nthreads(),
-             split::Symbol = :batch,
-             schedule::Symbol =:dynamic) :: Nothing
+```
+tmap(f, [OutputType], A::AbstractArray; 
+     nchunks::Int = 2 * nthreads(),
+     split::Symbol = :batch,
+     schedule::Symbol =:dynamic)
+```
+
+A multithreaded function like `Base.map`. Create a new container `similar` to `A` whose `i`th element is equal to `f(A[i])`. This container is filled in parallel on multiple tasks. The optional argument `OutputType` will select a specific output type for the returned container, and will generally incur fewer allocations than the version where `OutputType` is not specified.
+
+## Keyword arguments:
+
+  * `nchunks::Int` (default 2 * nthreads()) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+  * `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). This argument is ignored if `OutputType` is not specified.
+  * `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
+
+
+</details>
+</p>
+
+____________________________
+
+<details><summary> tmap! </summary>
+<p>
+
+```
+tmap!(f, out, A::AbstractArray; 
+      nchunks::Int = 2 * nthreads(),
+      split::Symbol = :batch,
+      schedule::Symbol =:dynamic)
+```
+
+A multithreaded function like `Base.map!`. In parallel on multiple tasks, this function assigns each element of `out[i] = f(A[i])` for each index `i` of `A` and `out`.
+
+## Keyword arguments:
+
+  * `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+  * `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter).
+  * `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
+
+
+</details>
+</p>
+
+____________________________
+
+<details><summary> tforeach </summary>
+<p>
+
+```
+tforeach(f, A::AbstractArray;
+         nchunks::Int = 2 * nthreads(),
+         split::Symbol = :batch,
+         schedule::Symbol =:dynamic) :: Nothing
+```
 
 Apply `f` to each element of `A` on multiple parallel tasks, and return `nothing`.
 
 ## Keyword arguments:
 
-- `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
+  * `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+  * `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
+  * `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
 
 
 </details>
 </p>
 
-____________________________________
+____________________________
 
-<details><summary>tmap</summary>
+<details><summary> tcollect </summary>
 <p>
 
-
-    tmap(f, ::Type{OutputType}, A::AbstractArray; 
+```
+tcollect(::Type{OutputType}, gen::Base.Generator{<:AbstractArray};
          nchunks::Int = 2 * nthreads(),
-         split::Symbol = :batch,
          schedule::Symbol =:dynamic)
+```
 
-A multithreaded function like `Base.map`. Create a new container `similar` to `A` with element type
-`OutputType`, whose `i`th element is equal to `f(A[i])`. This container is filled in parallel on multiple tasks.
+A multithreaded function like `Base.collect`. Essentially just calls `tmap` on the generator function and inputs.
 
 ## Keyword arguments:
 
-- `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
+  * `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+  * `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
 
 
 </details>
 </p>
 
-____________________________________
+____________________________
 
-<details><summary>tmap!</summary>
-<p>
-
-    tmap!(f, out, A::AbstractArray; 
-          nchunks::Int = 2 * nthreads(),
-          split::Symbol = :batch,
-          schedule::Symbol =:dynamic)
-
-A multithreaded function like `Base.map!`. In parallel on multiple tasks, this function assigns each element
-of `out[i] = f(A[i])` for each index `i` of `A` and `out`.
-
-## Keyword arguments:
-
-- `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
-- `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
-- `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
-
-</details>
-</p>

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This data is divided into chunks to be worked on in parallel using [ChunkSplitte
 ## Keyword arguments:
 
   * `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
-  * `nchunks::Int` (default 2 * nthreads()) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+  * `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
   * `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
   * `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
   * `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
@@ -153,7 +153,7 @@ A multithreaded function like `Base.map`. Create a new container `similar` to `A
 
 ## Keyword arguments:
 
-  * `nchunks::Int` (default 2 * nthreads()) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+  * `nchunks::Int` (default `2*nthreads())` is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
   * `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). This argument is ignored if `OutputType` is not specified.
   * `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
 

--- a/readme_generator.jl
+++ b/readme_generator.jl
@@ -1,0 +1,21 @@
+using ThreadsBasics
+
+open("README.md", "w+") do io
+    println(io, """
+# ThreadsBasics
+
+#### This package is in very early development and is not yet registered
+
+This is meant to be a simple, unambitious package that provides basic, user-friendly ways of doing 
+multithreaded calculations via higher-order functions, with a focus on [data parallelism](https://en.wikipedia.org/wiki/Data_parallelism).
+
+It re-exports the very useful function `chunks` from [ChunkSplitters.jl](https://github.com/m3g/ChunkSplitters.jl), and
+provides the following functions:
+""")
+    for sym ∈ (:tmapreduce, :treducemap, :treduce, :tmap, :tmap!, :tforeach, :tcollect)
+        println(io, "<details><summary> $sym </summary>\n<p>\n")
+        println(io, Base.Docs.doc(Base.Docs.Binding(ThreadsBasics, sym)))
+        println(io, "\n</details>\n</p>")
+        println(io, "\n____________________________\n")
+    end
+end

--- a/src/ThreadsBasics.jl
+++ b/src/ThreadsBasics.jl
@@ -105,7 +105,7 @@ This data is divided into chunks to be worked on in parallel using [ChunkSplitte
 ## Keyword arguments:
 
 - `init` optional keyword argument forwarded to `mapreduce` for the sequential parts of the calculation.
-- `nchunks::Int` (default 2 * nthreads()) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+- `nchunks::Int` (default `2*nthreads()`) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
 - `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). If `scatter` is chosen, then your reducing operator `op` **must** be [commutative](https://en.wikipedia.org/wiki/Commutative_property) in addition to being associative, or you could get incorrect results!
 - `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
 - `outputtype::Type` (default `Any`) will work as the asserted output type of parallel calculations. This is typically only
@@ -142,7 +142,7 @@ allocations than the version where `OutputType` is not specified.
 
 ## Keyword arguments:
 
-- `nchunks::Int` (default 2 * nthreads()) is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
+- `nchunks::Int` (default `2*nthreads())` is passed to `ChunkSplitters.chunks` to inform it how many pieces of data should be worked on in parallel. Greater `nchunks` typically helps with [load balancing](https://en.wikipedia.org/wiki/Load_balancing_(computing)), but at the expense of creating more overhead.
 - `split::Symbol` (default `:batch`) is passed to `ChunkSplitters.chunks` to inform it if the data chunks to be worked on should be contiguous (:batch) or shuffled (:scatter). This argument is ignored if `OutputType` is not specified.
 - `schedule::Symbol` either `:dynamic` or `:static` (default `:dynamic`), determines how the parallel portions of the calculation are scheduled. `:dynamic` scheduling is generally preferred since it is more flexible and better at load balancing, but `:static` scheduling can sometimes be more performant when the time it takes to complete a step of the calculation is highly uniform, and no other parallel functions are running at the same time.
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test, ThreadsBasics
 
 @testset "Basics" begin
     for (~, f, op, itr) ∈ [
-        (isapprox, sin, +, rand(ComplexF64, 100)),
+        (isapprox, sin, +, rand(ComplexF64, 10, 10)),
         (isapprox, cos, max, 1:100000),
         (==, round, vcat, randn(1000)),
         (==, last, *, [1=>"a", 2=>"b", 3=>"c", 4=>"d", 5=>"e"])
@@ -25,6 +25,10 @@ using Test, ThreadsBasics
                     @test all(tmap(f, Any, itr; kwargs...) .~ map_f_itr)
                     @test all(tcollect(Any, (f(x) for x in itr); kwargs...) .~ map_f_itr)
                     @test all(tcollect(Any, f.(itr); kwargs...) .~ map_f_itr)
+
+                    @test tmap(f, itr; kwargs...) ~ map_f_itr
+                    @test tcollect((f(x) for x in itr); kwargs...) ~ map_f_itr
+                    @test tcollect(f.(itr); kwargs...) ~ map_f_itr
                     
                     RT = Core.Compiler.return_type(f, Tuple{eltype(itr)})
                     


### PR DESCRIPTION
This is an alternative to https://github.com/MasonProtter/ThreadsBasics.jl/pull/2

Basic idea is just that if the user doesn't want to specify the output type of `tmap`, then we just do a sequential `map` on each task, and then join those results together using  `BangBang.append!!`. 

This is type stable and inference friendly, though it does result in more allocations and is generally a bit slower.